### PR TITLE
feat: added patreon chapter parsing first draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ opt-level = 2
 color-name = "1.1.0"
 epub-builder = "0.7.1"
 hex = "0.4.3"
-hyper = { version = "0.14.27", features = ["full"] }
-hyper-tls = "0.5.0"
+reqwest = { version = "0.12", features = ["cookies"] }
 image = "0.24.7"
 imageproc = "0.23.0"
 mail-builder = "0.3.0"

--- a/example_config.jsonc
+++ b/example_config.jsonc
@@ -12,6 +12,8 @@
     // also generate an an epub with colours stripped - will be set to true if any destination has StripColour set to true
     "StripColour": true
   },
+  // Prompt for user to fill in chapter password from patreon, false by default
+  "PatreonPrompt": false,
   // none of these are required if local generation is all you want
   "Mail": {
     "Name": "Email to send from",
@@ -29,7 +31,7 @@
         // If true, will strip colour from the epub, recommended if you use a kindle or other black and white reader
         // Stripped colours will look like <LIGHTSKYBLUE|Some light blue text|LIGHTSKYBLUE>
         "StripColour": true,
-        // If true will send all updated chapters as a single epub per updated volume 
+        // If true will send all updated chapters as a single epub per updated volume
         "SendFullVolumes": true,
         // If true will send an epub for each updated chapter
         "SendIndividualChapters": true

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,7 @@ pub struct Config {
     // number of seconds to wait before allowing another request to be made
     // avoids being ip banned
     pub request_delay: u64,
+    pub patreon_prompt: bool,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -79,6 +80,7 @@ impl Default for Config {
             request_delay: 1000,
             mail: MailConfig::default(),
             epub_gen: EpubGenConfig::default(),
+            patreon_prompt: false,
         }
     }
 }

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -1,6 +1,5 @@
 use color_name::Color;
 use epub_builder::{EpubBuilder, EpubContent, ZipLibrary};
-use hex;
 use image::io::Reader as ImageReader;
 use image::Rgba;
 use imageproc::drawing::draw_text_mut;
@@ -35,9 +34,9 @@ fn generate_cover(
         112,
         Scale::uniform(30.0),
         &font,
-        &volume_title,
+        volume_title,
     );
-    std::fs::create_dir_all(&output_dir)?;
+    std::fs::create_dir_all(output_dir)?;
     let path = output_dir.join(format!("{}.png", &volume_title));
     img.save(&path)?;
     Ok(path)
@@ -137,7 +136,7 @@ fn generate_chapters(
 ) -> Result<Vec<Attachment>, Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir.join("combined"))?;
 
-    if chapters.len() == 0 {
+    if chapters.is_empty() {
         return Ok(Vec::<Attachment>::default());
     }
 
@@ -193,7 +192,7 @@ fn generate_chapters(
         attachments.push(generate_chapter(
             db_conn,
             chapter,
-            &output_dir,
+            output_dir,
             strip_colour,
         )?);
         db::update_generated_chapter(db_conn, chapter.id, false)?;
@@ -205,7 +204,7 @@ fn generate_chapters(
         "{}({})-{}({}).epub",
         chapters[0].id, chapters[0].name, last_chapter.id, last_chapter.name
     )))?;
-    file.write(&combined_output)?;
+    file.write_all(&combined_output)?;
     Ok(attachments)
 }
 
@@ -256,7 +255,7 @@ fn generate_volume(
 
     epub.generate(&mut output)?;
 
-    std::fs::create_dir_all(&output_dir)?;
+    std::fs::create_dir_all(output_dir)?;
 
     let filename = format!("{}.epub", volume.name);
 
@@ -283,7 +282,7 @@ pub async fn generate_epubs(
     if config.epub_gen.volumes {
         let volumes = db::get_volumes_to_regenerate(db_conn)?;
 
-        if volumes.len() == 0 {
+        if volumes.is_empty() {
             println!("No volumes to generate");
         } else {
             println!("Generating epubs for {} volumes", volumes.len());
@@ -316,7 +315,7 @@ pub async fn generate_epubs(
 
     if config.epub_gen.chapters {
         let chapters = db::get_chapters_to_regenerate(db_conn)?;
-        if chapters.len() == 0 {
+        if chapters.is_empty() {
             println!("No chapters to generate");
             return Ok(());
         }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -75,5 +75,4 @@ pub async fn send_epubs(
             }
         }
     }
-    ()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,24 @@ async fn main() {
         }
     };
 
-    match scraper::update_index(&conn, &config.toc_url).await {
+    let client = match scraper::build_client(config.patreon_prompt).await {
+        Ok(client) => client,
+        Err(e) => panic!("Error building request client: {}", e),
+    };
+
+    match scraper::update_index(&conn, &config.toc_url, &client).await {
         Ok(_) => (),
         Err(e) => panic!("Error updating index: {}", e),
     }
 
-    match scraper::download_all_chapters(&conn, &config.request_delay).await {
+    match scraper::download_all_chapters(
+        &conn,
+        &config.request_delay,
+        config.patreon_prompt,
+        &client,
+    )
+    .await
+    {
         Ok(_) => (),
         Err(e) => panic!("Error getting chapters: {}", e),
     }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -140,7 +140,7 @@ pub async fn download_all_chapters(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let chapters = db::get_empty_chapters(db_conn)?;
 
-    if chapters.len() == 0 {
+    if chapters.is_empty() {
         println!("No chapters to download");
     } else {
         println!("Downloading {} missing chapters", chapters.len());
@@ -159,7 +159,7 @@ pub async fn download_all_chapters(
         if count > 0 {
             format!("Done downloading {count} chapters")
         } else {
-            format!("No chapters to download")
+            "No chapters to download".to_string()
         }
     );
     Ok(())

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -22,7 +22,7 @@ pub async fn build_client(parse_patreon: bool) -> Result<Client, Box<dyn std::er
         // prompt user for input value
         let mut password = String::new();
         print!("Enter patreon chapter password: ");
-        stdout().flush();
+        stdout().flush()?;
         stdin().read_line(&mut password).unwrap();
         let password = password.trim();
 


### PR DESCRIPTION
Added a first draft of patreon early chapter parsing (assuming you are subscribed to the patreon and have the chapter's password)

This is a pretty basic implementation for now, and will prompt for a password every time if the `PatreonPrompt` config is set to `true` even if there are no patreon specific chapters to download. I plan to improve the order of operations and fix this in [v2](/wandering_inn_scraper/tree/feat/v2-refactor) of the parser.